### PR TITLE
[WIP] Nina/32 create config

### DIFF
--- a/ApexDAG/argparser.py
+++ b/ApexDAG/argparser.py
@@ -9,3 +9,4 @@ argparser.add_argument("-s", "--save_prev", action="store_true", help="Store pre
 argparser.add_argument("-e", "--experiment", type=str, default="data_flow_graph_test", help="Experiment to run")
 argparser.add_argument("-d", "--draw", action="store_true", help="Draw AST-/Dataflow Graphs with graph_viz and matplotlib")
 argparser.add_argument("-c", "--checkpoint_path", type=str, default=None, help="Path to checkpoint directory")
+argparser.add_argument("--config_path", type=str, default="ApexDAG/experiments/configs/pretrain/default.yaml", help="Config file.")

--- a/ApexDAG/experiments/configs/pretrain/default.yaml
+++ b/ApexDAG/experiments/configs/pretrain/default.yaml
@@ -1,5 +1,5 @@
-checkpoint_path: "data/raw/pretrain-graphs"
-encoded_checkpoint_path: "data/raw/pretrain-graphs/pytorch-encoded"
+checkpoint_path: "/home/eggers/data/apexdag_results/jetbrains_dfg_100k_new/execution_graphs"
+encoded_checkpoint_path: "data/raw/pytorch-embedded"
 hidden_dim: 300
 num_heads: 4
 node_classes: 8
@@ -9,3 +9,12 @@ learning_rate: 0.001
 num_epochs: 100
 train_split: 0.8
 patience: 10
+
+#hyperparameters for encoder
+
+min_nodes: 3
+min_edges: 2
+
+
+# for testing, remove later on
+load_encoded_old_if_exist: True # if the graphs are encoded do not encode them once again.

--- a/ApexDAG/experiments/configs/pretrain/default.yaml
+++ b/ApexDAG/experiments/configs/pretrain/default.yaml
@@ -1,0 +1,11 @@
+checkpoint_path: "data/raw/pretrain-graphs"
+encoded_checkpoint_path: "data/raw/pretrain-graphs/pytorch-encoded"
+hidden_dim: 300
+num_heads: 4
+node_classes: 8
+edge_classes: 6
+batch_size: 32
+learning_rate: 0.001
+num_epochs: 100
+train_split: 0.8
+patience: 10

--- a/ApexDAG/experiments/pretrain.py
+++ b/ApexDAG/experiments/pretrain.py
@@ -12,7 +12,6 @@ from ApexDAG.encoder import Encoder
 from ApexDAG.notebook import Notebook
 from ApexDAG.util.kaggle_dataset_iterator import KaggleDatasetIterator
 
-from ApexDAG.sca.constants import EDGE_TYPES, NODE_TYPES
 from ApexDAG.sca.graph_utils import save_graph, load_graph
 from ApexDAG.sca.py_data_flow_graph import PythonDataFlowGraph as DataFlowGraph
 
@@ -21,117 +20,170 @@ from ApexDAG.nn.dataset import GraphDataset
 from ApexDAG.nn.trainer import PretrainingTrainer
 
 
+class GraphProcessor:
+    """Handles loading and preprocessing of graphs."""
+    def __init__(self, checkpoint_path: Path, logger: logging.Logger):
+        self.checkpoint_path = checkpoint_path
+        self.logger = logger
+        self.graphs = []
+
+    def check_graph(self, G):
+        """Ensures graph attributes are properly formatted."""
+        for node, data in G.nodes(data=True):
+            for key in data:
+                data[key] = "None" if data[key] is None else str(data[key])
+
+        for u, v, data in G.edges(data=True):
+            for key in data:
+                data[key] = "None" if data[key] is None else str(data[key])
+
+    def load_preprocessed_graphs(self):
+        """Loads preprocessed graphs from the checkpoint path."""
+        if not self.checkpoint_path.exists():
+            raise FileNotFoundError(f"Checkpoint path {self.checkpoint_path} does not exist")
+
+        self.logger.info("Loading preprocessed graphs...")
+        errors = 0
+        graph_files = list(self.checkpoint_path.iterdir())[:100]
+        
+        for graph_file in tqdm.tqdm(graph_files, desc="Loading graphs"):
+            try:
+                graph = load_graph(graph_file)
+                self.graphs.append(graph)
+            except Exception:
+                self.logger.error(f"Error in graph {graph_file}")
+                self.logger.error(traceback.format_exc())
+                errors += 1
+
+        self.logger.info(f"Loaded {len(self.graphs)} graphs with {errors} errors")
+
+class GraphEncoder:
+    """Handles encoding of graphs into tensors for training."""
+    def __init__(self, encoded_checkpoint_path: Path, logger: logging.Logger, min_nodes: int, min_edges: int, load_encoded_old_if_exist: bool):
+        self.encoded_checkpoint_path = encoded_checkpoint_path
+        self.logger = logger
+        self.encoded_graphs = []
+        
+        # hyperparams
+        self.min_nodes = min_nodes
+        self.min_edges = min_edges
+        
+        # for testing, remove if not needed downstream
+        self.load_old_if_exist = load_encoded_old_if_exist
+
+    def encode_graphs(self, graphs):
+        """Encodes graphs and saves them to disk."""
+        if self.encoded_checkpoint_path.exists() and self.load_old_if_exist:
+            self.logger.info("Loading encoded graphs...")
+            self.encoded_graphs = [
+                torch.load(self.encoded_checkpoint_path / path)
+                for path in tqdm.tqdm(os.listdir(self.encoded_checkpoint_path), desc="Loading encoded graphs")
+            ]
+        else:
+            self.logger.info("Encoding graphs...")
+            os.makedirs(self.encoded_checkpoint_path, exist_ok=True)
+            encoder = Encoder()
+
+            for index, graph in tqdm.tqdm(enumerate(graphs), desc="Encoding graphs"):
+                if len(graph.nodes) < self.min_nodes and len(graph.edges) < self.min_edges:
+                    continue  # skip small graphs
+
+                try:
+                    encoded_graph = encoder.encode(graph)
+                    torch.save(encoded_graph, self.encoded_checkpoint_path / f"graph_{index}.pt")
+                    self.encoded_graphs.append(encoded_graph)
+                except KeyboardInterrupt:
+                    self.logger.warning("Encoding interrupted, continuing with next graph...")
+                    continue
+
+        return self.encoded_graphs
+
+
+class GATTrainer:
+    """Handles model training."""
+    def __init__(self, config, logger: logging.Logger):
+        self.config = config
+        self.logger = logger
+
+    def train(self, encoded_graphs):
+        """Trains the GAT model."""
+        dataset = GraphDataset(encoded_graphs)
+        train_size = int(self.config["train_split"] * len(dataset))
+        val_size = len(dataset) - train_size
+        train_dataset, val_dataset = random_split(dataset, [train_size, val_size])
+
+        model = MultiTaskGAT(
+            hidden_dim=self.config["hidden_dim"], 
+            num_heads=self.config["num_heads"], 
+            node_classes=self.config["node_classes"], 
+            edge_classes=self.config["edge_classes"]
+        )
+        # TODO: need to add wandb logging (as in issue #38)
+        trainer = PretrainingTrainer(model, train_dataset, val_dataset, device="cpu", patience=self.config["patience"])
+        trainer.train(num_epochs=self.config["num_epochs"])
+
+
+class GATPretrainer:
+    """Main class to orchestrate the GAT pretraining pipeline."""
+    def __init__(self, args):
+        self.args = args
+        self.logger = self.setup_logger()
+
+        # configuration loading
+        with open(args.config_path, "r") as f:
+            self.config = yaml.safe_load(f)
+
+        self.checkpoint_path = Path(self.config["checkpoint_path"])
+        self.encoded_checkpoint_path = Path(self.config["encoded_checkpoint_path"]).parent / "pytorch-encoded"
+
+        # processing components
+        self.graph_processor = GraphProcessor(self.checkpoint_path, self.logger)
+        self.graph_encoder = GraphEncoder(self.encoded_checkpoint_path, self.logger)
+        self.trainer = GATTrainer(self.config, self.logger)
+
+    def setup_logger(self):
+        """Sets up the logger."""
+        logging.basicConfig(level=logging.INFO)
+        return logging.getLogger(__name__)
+
+    def run(self):
+        """Runs the full training pipeline."""
+        # load or mine graphs
+        if not self.graph_processor.load_preprocessed_graphs():
+            self.graph_processor.mine_dataflows(self.args)
+
+        # encode graphs
+        encoded_graphs = self.graph_encoder.encode_graphs(self.graph_processor.graphs)
+
+        # train model
+        self.trainer.train(encoded_graphs)
+
+
 def signal_handler(signum, frame):
+    """Handles interrupt signals (Ctrl+C)."""
     global interrupted
     interrupted = True
 
-signal.signal(signal.SIGINT, signal_handler) 
+signal.signal(signal.SIGINT, signal_handler)
 
-def check_graph(G):
-    for node, data in G.nodes(data=True):
-        for key in data:
-            if data[key] is None:
-                data[key] = "None"
-            else:
-                data[key] = str(data[key])
-
-    for u, v, data in G.edges(data=True):
-        for key in data:
-            if data[key] is None:
-                data[key] = "None"
-            else:
-                data[key] = str(data[key])
 
 def pretrain_gat(args, logger: logging.Logger) -> None:
-    # Load configuration
+    """Main entry point for pretraining the GAT model."""
     with open(args.config_path, "r") as f:
         config = yaml.safe_load(f)
 
     checkpoint_path = Path(config["checkpoint_path"])
-    checkpoint_encoded_path = Path(config["encoded_checkpoint_path"])
+    encoded_checkpoint_path = Path(config["encoded_checkpoint_path"]).parent / "pytorch-encoded"
 
-    logger.info("Checkpoint path: %s", checkpoint_path)
-    if checkpoint_path.exists():
-        errors = 0
-        count = 0
-        logger.info("Loading preprocessed graphs")
-        graphs = []
-        directory_content = list(checkpoint_path.iterdir())
-        progress_bar = tqdm.tqdm(directory_content, desc="Loading graphs")
-        for graph in progress_bar:
-            count += 1
-            try:
-                graph = load_graph(graph)
-                graphs.append(graph)
-            except:
-                progress_bar.write(f"Errror in graph {graph}")
-                tb = traceback.format_exc()
-                progress_bar.write(tb)
-                errors += 1
+    graph_processor = GraphProcessor(checkpoint_path, logger)
+    graph_encoder = GraphEncoder(encoded_checkpoint_path, logger, config['min_nodes'], config['min_edges'], config['load_encoded_old_if_exist'])
+    trainer = GATTrainer(config, logger)
 
-        info_str = f"Errors in {errors}/{count} graphs"
-        logger.info(info_str)
-    else:
-        kaggle_iterator = KaggleDatasetIterator(os.path.join(args.notebook))
+    # load or mine graphs
+    graph_processor.load_preprocessed_graphs()
 
-        logger.info("Mining dataflows on Kaggle dataset")
-        graphs = []
-        for competition in kaggle_iterator:
-            for notebook_file in competition["ipynb_files"]:
-                notebook_path = os.path.join(competition["subfolder_path"], notebook_file)
-                notebook = Notebook(notebook_path)
-                notebook.create_execution_graph(greedy=args.greedy)
-                dfg = DataFlowGraph(notebook_file)
-                dfg.parse_notebook(notebook)
-                dfg.optimize()
-                graphs.append(dfg.get_graph())
+    # encode graphs
+    encoded_graphs = graph_encoder.encode_graphs(graph_processor.graphs)
 
-        os.makedirs(str(checkpoint_path), exist_ok=True)
-        for index, graph in enumerate(graphs):
-            check_graph(graph)
-            save_graph(graph, checkpoint_path / f"graph_{index}.gml")
-
-    checkpoint_path = checkpoint_encoded_path.parent / "pytorch-encoded"
-    if checkpoint_path.exists():
-        logger.info("Loading encoded graphs")
-        encoded_graphs = [
-            torch.load(os.path.join(str(checkpoint_path), path))
-            for path
-            in tqdm.tqdm(os.listdir(str(checkpoint_path)), desc="Loading encoded graphs")
-        ]
-    else:
-        logger.info("Encoding graphs")
-        os.makedirs(str(checkpoint_path), exist_ok=True)
-        encoder = Encoder()
-        load_bar = tqdm.tqdm(enumerate(graphs), desc="Encoding graphs")
-        for index, graph in load_bar:
-            if hasattr(graph, "nodes") and len(graph.nodes) < 3 and hasattr(graph, "edges") and len(graph.edges) < 2:
-                continue
-            try:
-                msg = f"Encoding graph {index} with nodes {len(graph.nodes)} and edges {len(graph.edges)}"
-                load_bar.write(msg)
-                encoded_graph = encoder.encode(graph)
-                torch.save(encoded_graph, checkpoint_path / f"graph_{index}.pt")
-            except KeyboardInterrupt:
-                load_bar.write("Interrupted, continuing with next graph")
-                continue
-
-    logger.info("Creating dataset")
-    dataset = GraphDataset(encoded_graphs)
-    dataset_size = len(dataset)
-    train_size = int(config["train_split"] * dataset_size)
-    val_size = dataset_size - train_size
-
-    # Randomly split the dataset
-    train_dataset, val_dataset = random_split(dataset, [train_size, val_size])
-
-    model = MultiTaskGAT(
-        hidden_dim=config["hidden_dim"], 
-        num_heads=config["num_heads"], 
-        node_classes=config["node_classes"], 
-        edge_classes=config["edge_classes"]
-    )
-    print(model)
-    # Instantiate the trainer
-    trainer = PretrainingTrainer(model, train_dataset, val_dataset, device="cpu", patience=config["patience"])
-    trainer.train(num_epochs=config["num_epochs"])
+    # train model
+    trainer.train(encoded_graphs)


### PR DESCRIPTION
#32  Added propper config, so that hyperparam tuning can be performed easily. the config includes :
```
checkpoint_path: "/home/eggers/data/apexdag_results/jetbrains_dfg_100k_new/execution_graphs"
encoded_checkpoint_path: "data/raw/pytorch-embedded"
hidden_dim: 300
num_heads: 4
node_classes: 8
edge_classes: 6
batch_size: 32
learning_rate: 0.001
num_epochs: 100
train_split: 0.8
patience: 10

#hyperparameters for encoder

min_nodes: 3
min_edges: 2


# for testing, remove later on
load_encoded_old_if_exist: True # if the graphs are encoded do not encode them once again.
```

i.e. checkpoint path is made redundant and will need to be deleted from the main argparser, but this needs to be discussed. @S-Eggers. 


Other than that, redundant code for example the kaggle iterator is deleted and OOP-like code is introduced. 

model logging compliant with #38 will be needed to be added in the pretraing.py or in the pretraining trainer.



**I also suggest putting model architecture here, however it is defined in the MultiTaskGAT (i mean number of layers, ideally putting in BLOCKS, also I am not sure but layernorms should be better here than batchnorms)...**